### PR TITLE
feat: open coupon by id params

### DIFF
--- a/src/components/orgs/SupplierCoupons/index.tsx
+++ b/src/components/orgs/SupplierCoupons/index.tsx
@@ -47,7 +47,7 @@ const SupplierCoupons: React.FC<SupplierCouponsProps> = ({
   const [showCouponModal, setShowCouponModal] = useState(false);
   const [currentStep, setCurrentStep] = useState<number>(STEPS.SHOWING_COUPON);
   const searchParams = useSearchParams();
-  const params = searchParams.get("coupon");
+  const couponIdParam = searchParams.get("coupon");
 
   const handleNextStep = (step: number) => setCurrentStep(step);
 
@@ -72,10 +72,10 @@ const SupplierCoupons: React.FC<SupplierCouponsProps> = ({
   }, [currentStep]);
 
   useEffect(() => {
-    if (id === params) {
+    if (id === couponIdParam) {
       setShowCouponModal(true);
     }
-  }, [id, params]);
+  }, [id, couponIdParam]);
 
   const StepOne = () => {
     return (

--- a/src/components/orgs/SupplierCoupons/index.tsx
+++ b/src/components/orgs/SupplierCoupons/index.tsx
@@ -9,6 +9,7 @@ import couponsService from "@/service/coupons.service";
 import { showToastify } from "@/hooks/showToastify";
 import { AxiosResponse } from "axios";
 import CouponCard from "@/components/mols/CouponCard";
+import { useSearchParams } from "next/navigation";
 
 interface SupplierCouponsProps {
   couponTitle: string;
@@ -45,6 +46,8 @@ const SupplierCoupons: React.FC<SupplierCouponsProps> = ({
   const [couponCode, setCouponCode] = useState("");
   const [showCouponModal, setShowCouponModal] = useState(false);
   const [currentStep, setCurrentStep] = useState<number>(STEPS.SHOWING_COUPON);
+  const searchParams = useSearchParams();
+  const params = searchParams.get("coupon");
 
   const handleNextStep = (step: number) => setCurrentStep(step);
 
@@ -67,6 +70,12 @@ const SupplierCoupons: React.FC<SupplierCouponsProps> = ({
       }, 1500);
     }
   }, [currentStep]);
+
+  useEffect(() => {
+    if (id === params) {
+      setShowCouponModal(true);
+    }
+  }, [id, params]);
 
   const StepOne = () => {
     return (


### PR DESCRIPTION
to automatically open the cupon, pass in the query params "coupon = id of the coupon".

example to open the coupon of felipe suplementos...
/supplier-dashboard/6516cfc4d6301100295baf67?coupon=652afd755233ee0029d52f6c